### PR TITLE
Removed unnecessary reference to window object

### DIFF
--- a/firstJSPage/index.html
+++ b/firstJSPage/index.html
@@ -6,9 +6,9 @@
 <body>
   <h1>My first JS page</h1>
   <script type="text/javascript">
-    window.alert("My site is extremely awesome so enjoy with caution!");
-    var person = window.prompt("What's your name?");
-    window.alert(person + ", welcome to my site!! Enjoy!!");
+    alert("My site is extremely awesome so enjoy with caution!");
+    var person = prompt("What's your name?");
+    alert(person + ", welcome to my site!! Enjoy!!");
   </script>
 </body>
 </html>


### PR DESCRIPTION
The window object contains (among other things!) the global namespace, which is why alert, prompt, and all other global objects are window properties. But since they are part of the global namespace, calling them via window is pointless. You can just call them directly!